### PR TITLE
Reuse the same 'adb shell' process for faster diff times

### DIFF
--- a/src/ADBSync/FileSystems/Base.py
+++ b/src/ADBSync/FileSystems/Base.py
@@ -1,23 +1,10 @@
 from __future__ import annotations
-from typing import Iterable, Iterator, List, Tuple, Union
+from typing import Iterable, Tuple, Union
 import logging
 import os
 import stat
-import subprocess
 
 class FileSystem():
-    def __init__(self, adb_arguments: List[str]) -> None:
-        self.adb_arguments = adb_arguments
-
-    def adbShell(self, commands: List[str]) -> Iterator[str]:
-        with subprocess.Popen(
-            self.adb_arguments + ["shell"] + commands,
-            stdout = subprocess.PIPE, stderr = subprocess.STDOUT
-        ) as proc:
-            while adbLine := proc.stdout.readline():
-                adbLine = adbLine.decode().rstrip("\r\n")
-                yield adbLine
-
     def _getFilesTree(self, tree_path: str, tree_path_stat: os.stat_result, followLinks: bool = False):
         # the reason to have two functions instead of one purely recursive one is to use self.lstat_inDir ie ls
         # which is much faster than individually stat-ing each file. Hence we have getFilesTree's special first lstat

--- a/src/ADBSync/__init__.py
+++ b/src/ADBSync/__init__.py
@@ -2,7 +2,7 @@
 
 """Better version of adb-sync for Python3"""
 
-__version__ = "1.1.6"
+__version__ = "1.2.0"
 
 from typing import List, Tuple, Union
 import logging
@@ -338,7 +338,7 @@ def main():
         adb_arguments.append(value)
 
     fs_android = AndroidFileSystem(adb_arguments)
-    fs_local = LocalFileSystem(adb_arguments)
+    fs_local = LocalFileSystem()
 
     if not fs_android.testConnection():
         criticalLogExit("No device detected")


### PR DESCRIPTION
By reusing the same `adb shell` process and feeding commands to its stdin, the time taken to fetch the Android file tree can be reduced, since there is less overhead not having to create an adb connection for every operation.

Using `time` I've noticed the time taken to do a dry run of syncing my ~/Music folder go from `real    0m21.661s` to `real    0m16.275s`; about a 25% speedup.